### PR TITLE
Add placeholder files to retain legacy directories in git

### DIFF
--- a/04_LegacyContent/_Backup/Assessments/.keep
+++ b/04_LegacyContent/_Backup/Assessments/.keep
@@ -1,0 +1,1 @@
+Placeholder to retain this legacy directory in git. See ORGANIZATION_GUIDE deprecation policy. Remove when populated or formally retired.

--- a/04_LegacyContent/_Backup/StudyGuides/.keep
+++ b/04_LegacyContent/_Backup/StudyGuides/.keep
@@ -1,0 +1,1 @@
+Placeholder to retain this legacy directory in git. See ORGANIZATION_GUIDE deprecation policy. Remove when populated or formally retired.

--- a/04_LegacyContent/_Backup/Templates/.keep
+++ b/04_LegacyContent/_Backup/Templates/.keep
@@ -1,0 +1,1 @@
+Placeholder to retain this legacy directory in git. See ORGANIZATION_GUIDE deprecation policy. Remove when populated or formally retired.


### PR DESCRIPTION
This pull request adds placeholder `.keep` files to several legacy backup directories. These placeholders ensure that empty directories are retained in version control according to the deprecation policy, and can be removed once the directories are populated or officially retired.