### PR TITLE
Update deprecated agenda stubs and enhance README with library maps

### DIFF
--- a/03_ReferenceLibrary/01_Development/04_Git-Version-Control/1-Git-GitHub-Workshop-Agenda.md
+++ b/03_ReferenceLibrary/01_Development/04_Git-Version-Control/1-Git-GitHub-Workshop-Agenda.md
@@ -1,66 +1,17 @@
-# Introduction to Git and GitHub — 1-Hour Workshop Agenda
+# Deprecated Duplicate: Session 1 Agenda Stub
 
-**Audience:** Beginners, practitioners new to version control or GitHub
-**Duration:** 1 hour
-**Source:** Consolidated from Microsoft Learn modules and best practices
+> DEPRECATED FILE DUPLICATE  
+> This file duplicated the canonical numbered agenda: `01_Git-GitHub-Workshop-Agenda.md`  
+> Retained temporarily to avoid broken references. Remove after: 2025-09-15 (≈30 day grace).  
+> Please update any bookmarks or links to point to the numbered file and delete this stub when confirmed unused.
 
----
+## Replacement
 
-## 📅 Session Agenda (1 Hour)
+Use `01_Git-GitHub-Workshop-Agenda.md` for the full Session 1 agenda.
 
-**Title:** *Introduction to Git, and GitHub*
+## Rationale
 
-### 1. Welcome & Session Overview (5 min)
-
-- Trainer introduction
-- Purpose of the session
-- Quick poll: participants’ prior knowledge of Git/GitHub
+Numbered naming enforces ordering and future scalability for additional sessions.
 
 ---
-
-### 2. Introduction to Git (Version Control Basics) (10 min)
-
-- What is Version Control? Why it matters
-- Centralized vs Distributed VCS
-- Introduction to Git as the most popular DVCS
-
----
-
-### 3. Hands-on with Git Basics (15 min)
-
-- Creating a new Git repository (`git init`)
-- Configuring Git (`git config`)
-- Tracking changes (`git add`, `git commit`)
-- Viewing history (`git log`)
-- Recovering from mistakes (`git checkout`, `git reset`)
-
----
-
-### 4. Introduction to GitHub (10 min)
-
-- What is GitHub?
-- GitHub as a collaborative platform
-- Key features: Repositories, Issues, Pull Requests, Discussions
-
----
-
-### 5. GitHub Flow in Action (15 min)
-
-- Cloning a repo (`git clone`)
-- Branching & making commits (`git branch`, `git checkout`, `git commit`)
-- Pushing changes to GitHub (`git push`)
-- Creating a Pull Request and merging changes
-
----
-
-### 6. Wrap-up & Q&A (5 min)
-
-- Summary of key takeaways
-- Common next steps (practice, resources, GitHub learning paths)
-- Questions from participants
-
----
-
-> This structure keeps **30 min for Git**, **25 min for GitHub**, and **5 min buffer** for wrap-up/Q&A.
-
----
+Last Reviewed: 2025-08-24

--- a/03_ReferenceLibrary/01_Development/04_Git-Version-Control/2-GitHub-Collaboration-Session2-Agenda.md
+++ b/03_ReferenceLibrary/01_Development/04_Git-Version-Control/2-GitHub-Collaboration-Session2-Agenda.md
@@ -1,111 +1,17 @@
-# Session 2 — Getting Started with GitHub: Collaboration, Management, and Hands-on Practice
+# Deprecated Duplicate: Session 2 Agenda Stub
 
-**Learning Level:** Beginner → Early Practitioner  
-**Prerequisites:** Basic Git (init, add, commit, branch, push), attended Session 1 or equivalent  
-**Duration:** 60 minutes  
-**Session Type:** Demo + Guided Practice  
-**Last Updated:** 2025-08-19
+> DEPRECATED FILE DUPLICATE  
+> This file duplicated the canonical numbered agenda: `02_GitHub-Collaboration-Session2-Agenda.md`  
+> Retained temporarily to avoid broken references. Remove after: 2025-09-15 (≈30 day grace).  
+> Please update any bookmarks or links to point to the numbered file and delete this stub when confirmed unused.
 
----
+## Replacement
 
-## 🎯 Learning Objectives (What Participants Will Be Able To Do)
+Use `02_GitHub-Collaboration-Session2-Agenda.md` for the full Session 2 agenda.
 
-By the end of this session, participants can:
+## Rationale
 
-1. Explain how GitHub enables collaborative workflows (issues → branches → PRs → merge).
-2. Configure basic repository settings (visibility, collaborators, branch protection awareness).
-3. Navigate core UI areas: Code, Issues, Pull Requests, Actions, Insights.
-4. Use GitHub Desktop to clone, commit, and sync changes without the CLI.
-5. Complete a minimal Pull Request workflow (branch, change, PR, review, merge) end-to-end.
-6. Identify next-step resources for deeper learning (Actions, Discussions, Project boards).
+Numbered naming enforces ordering and future scalability for additional sessions.
 
 ---
-
-## 🧾 Session Agenda (1 Hour)
-
-### 1. GitHub as a Collaborative Platform (10 min)
-
-- Overview of GitHub's role in modern development ecosystems
-- Collaboration surfaces: Issues, Discussions, Pull Requests
-- Transparency & audit trail (commit history, review metadata)
-
-### 2. GitHub Platform Management (10 min)
-
-- Repository types: public vs private (when to choose which)
-- Access control basics (collaborators vs forks)
-- Notifications, watching, and subscription hygiene
-- Mention branch protection (teaser for future session)
-
-### 3. Exercise – Guided Tour of GitHub (10 min)
-
-- Live walkthrough: repo home → code view → commit diff → branches
-- Explore Issues: labels, assignees, commenting
-- Pull Requests: conversation tab vs commits vs files changed
-
-### 4. GitHub Desktop (10 min)
-
-- Install & first-run setup (sign-in, cloning a repo)
-- Visual diff & staging chunks (partial commit mindset)
-- Sync (fetch/pull) vs push — clarifying directionality
-
-### 5. Live Demo – Pull Request Workflow (15 min)
-
-Workflow Demonstrated:
-
-1. Create a feature branch (Desktop or CLI)  
-2. Make a small change (e.g., edit README)  
-3. Commit with a convention (feat/docs chore)  
-4. Push branch → open Pull Request  
-5. Add description + reference an issue (if any)  
-6. Reviewer comment + update commit (amend or follow-up commit)  
-7. Merge (squash vs merge commit rationale)  
-8. Delete branch and confirm main updated
-
-### 6. Wrap-up & Q&A (5 min)
-
-- Recap: Collaboration surfaces + PR flow + Desktop utility
-- Highlight next exploration areas: Actions, Projects, Codespaces
-- Provide resource list (GitHub Docs, Microsoft Learn paths)
-
----
-
-## 🧪 Quick Success Checks (Facilitator Prompts)
-
-| Check | Prompt | Target Outcome |
-| ----- | ------ | -------------- |
-| UI Navigation | "Open the latest commit diff" | Participant reaches commit view quickly |
-| Branching | "Show me your new branch locally" | Local branch exists & tracked |
-| PR Creation | "Paste your PR URL" | PR created with description |
-| Review Response | "Apply suggested change & push" | Update appears in PR timeline |
-| Merge Choice | "Why choose squash here?" | Can articulate clean history benefit |
-
----
-
-## 🧩 Optional Stretch (If Ahead of Time)
-
-- Add a CODEOWNERS file and open a PR to show automatic reviewer assignment
-- Enable Discussions and create a starter topic
-- Create a draft PR to illustrate early feedback workflows
-
----
-
-## 📚 Suggested Resources
-
-| Topic | Resource |
-| ----- | -------- |
-| Git Basics | (Session 1 Agenda) |
-| PR Best Practices | GitHub Docs → Pull Requests Guide |
-| Branching Strategies | Future session / internal guide (coming soon) |
-| GitHub Desktop | Official GitHub Desktop Docs |
-| Automation | GitHub Actions Quickstart (future module) |
-
----
-
-## 🔗 Related Internal Content
-
-- `1-Git-GitHub-Workshop-Agenda.md` (Session 1)  
-- `../02_software-design-principles/` (code review quality & structure)  
-- `../../02_AI-and-ML/07_AI-Agents/` (collaborative experimentation patterns)
-
----
-_Status: Initial draft for Session 2. Pending future linkage to advanced modules (branch protection, Actions, security)._
+Last Reviewed: 2025-08-24

--- a/03_ReferenceLibrary/01_Development/04_Git-Version-Control/GitHub-Collaboration-Session2-Agenda.md
+++ b/03_ReferenceLibrary/01_Development/04_Git-Version-Control/GitHub-Collaboration-Session2-Agenda.md
@@ -1,13 +1,13 @@
 # Deprecated Duplicate: Session 2 Agenda Stub
 
 > DEPRECATED FILE DUPLICATE  
-> This file is a duplicate of the canonical numbered agenda: `2-GitHub-Collaboration-Session2-Agenda.md`  
+> This file is a duplicate of the canonical numbered agenda: `02_GitHub-Collaboration-Session2-Agenda.md`  
 > Retained temporarily to avoid broken references. Remove after: 2025-09-15 (≈30 day grace)  
 > Please update any bookmarks or links to point to the numbered file and delete this stub when confirmed unused.
 
 ## Replacement
 
-Use `2-GitHub-Collaboration-Session2-Agenda.md` for the full Session 2 agenda.
+Use `02_GitHub-Collaboration-Session2-Agenda.md` for the full Session 2 agenda.
 
 ## Rationale
 

--- a/03_ReferenceLibrary/README.md
+++ b/03_ReferenceLibrary/README.md
@@ -79,6 +79,11 @@ Perfect for: Software engineers, system architects, and anyone building technica
 - **Data Science Track**: **[03_Data-Science/README.md](03_Data-Science/README.md)**
 - **Development Track**: **[01_Development/README.md](01_Development/README.md)**
 
+### Library Maps
+
+- Reference Index: **[INDEX.md](INDEX.md)**
+- Taxonomy Map: **[TAXONOMY_MAP.md](TAXONOMY_MAP.md)**
+
 ### **� Key Resources**
 
 - **AI Learning Roadmap**: **[02_AI-and-ML/01_AI/07_AI-Terms-Learning-Order.md](02_AI-and-ML/01_AI/07_AI-Terms-Learning-Order.md)**


### PR DESCRIPTION
This pull request primarily addresses the deprecation and cleanup of duplicate workshop agenda files in the Git version control reference library. The changes introduce clear stub messages in the duplicate files, direct users to the canonical numbered agendas, and update references for consistency. Additionally, a small improvement adds a library map to the main reference README.

**Deprecation and Cleanup of Duplicate Agenda Files:**

* Added explicit deprecation notices and stub content to `1-Git-GitHub-Workshop-Agenda.md` and `2-GitHub-Collaboration-Session2-Agenda.md`, instructing users to use the canonical numbered files (`01_Git-GitHub-Workshop-Agenda.md` and `02_GitHub-Collaboration-Session2-Agenda.md`) and specifying a removal grace period. [[1]](diffhunk://#diff-f0cd864a15019e24e6ab005a677091ced8810ecfb406a6633536483ca44a5ba1L1-R17) [[2]](diffhunk://#diff-94ee5dce319b57e1fb16aaedddab5270ce8cf6795692facc1cc55497b26692f1L1-R17) [[3]](diffhunk://#diff-0a679e1f25232e713b50ea473ec4f4773a1ef71f3878d7892af5f047c2d7eb59L4-R10)
* Corrected the canonical reference in the stub for Session 2 agenda to use the properly numbered filename (`02_GitHub-Collaboration-Session2-Agenda.md`).

**Reference Library Improvements:**

* Added a "Library Maps" section to `README.md`, providing quick links to the reference index and taxonomy map for easier navigation.